### PR TITLE
fix typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -287,7 +287,7 @@ ReactDadata.propTypes = {
   debounce: PropTypes.number,
   onChange: PropTypes.func,
   onIdleOut: PropTypes.func,
-  payloadModifier: PropTypes.oneOf(PropTypes.shape, PropTypes.func),
+  payloadModifier: PropTypes.oneOf([PropTypes.shape, PropTypes.func]),
   placeholder: PropTypes.string,
   query: PropTypes.string,
   showNote: PropTypes.bool,


### PR DESCRIPTION
u forgot this and i have warning when use yours code)
```Warning: Invalid arguments supplied to oneOf, expected an array, got 2 arguments. A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).```